### PR TITLE
Refactor comments in classification layer to fit software engineering conventions

### DIFF
--- a/classificationScreening/classify.py
+++ b/classificationScreening/classify.py
@@ -25,8 +25,19 @@ data_path = "classificationScreening/classification_data"
 classify = None
 transform = None
 
+
 def load_mobileNet_classifier(state_dict_path):
-    # Ignore depreciation warnings --> It works fine for our needs
+    """
+    Initialises the weights of the Mobile Net v3 model architecture to the pre-trained weights
+    stored in the model state dictionairy in the 'models' directory
+    
+    Args:
+        state_dict_path (string): The path to the state dictionairy relative to the function call
+    
+    Returns:
+        model (MobileNetV3 object): An initialised mobilenet v3 model with the saved weights,
+          in evaluation mode so the weights will not be changed
+    """
     model = models.mobilenet_v3_small()
     model.classifier[3] = torch.nn.Linear(model.classifier[3].in_features, 2)
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
@@ -39,8 +50,22 @@ def load_mobileNet_classifier(state_dict_path):
 classify = load_mobileNet_classifier(mobileNet_path)
 transform = classUtils.vgg_transform
 
-# Expects a numpy array image
 def infer(image, infer_model=classify, infer_transform=transform):
+    """
+    Applies a binary classification model to an input image array, generalising the inference
+    process to be model-independent. 
+
+    Args:
+        image (numpy array): The input image(s) in the form of a numpy array of form
+            [channels: [width: [height:]]] or [batch: [channels: [width: [height:]]]]
+        infer_model (pytorch model object): Any binary classification pytorch model object with a forward method
+        infer_transform (pytorch transform object): Any pre-processing required for the model to run
+    
+    Returns:
+        probs (tensor): A list of binary classifaction confidences in the range [0, 1], 
+            where each member of the batch sums to 1.
+
+    """
     # If infer model and transform have not been initialised
     if infer_model is None or infer_transform is None:
         raise TypeError("Error: The inference classes have not been initialised properly.")
@@ -58,6 +83,17 @@ def infer(image, infer_model=classify, infer_transform=transform):
     return probs
 
 def PIL_infer(image, threshold=0.35):
+    """
+    A wrapper function for the infer function that ensures compatibility with the PIL image library format
+    and that works for a single image only. Uses the system default model.
+
+    Args:
+        image (PIL image): The image that will be classified in PIL format
+        threshold (float): The confidence threshold for postiive classification
+    
+    Returns:
+        classification (boolean): Whether the image is likely to be the target object.
+    """
     tensor_im = torchvision.transforms.functional.pil_to_tensor(image).float()/ 255
     prediction = infer(tensor_im)
     classification = prediction[0][0] > threshold
@@ -65,6 +101,20 @@ def PIL_infer(image, threshold=0.35):
 
 # Expects a numpy image
 def infer_and_display(image, threshold, actual_label, onlyWrong=False):
+    """
+    A wrapper for the infer function that allows a visual representation of the model's classification, for 
+    demonstration, debuggin and model fine-tuning. Uses the system default model.
+
+    Args:
+        image (numpy array): The batch of images that will be classified
+        threshold (float): The minimum probability required for a positive classification
+        actual label (boolean array): The ground truth class labels of the input image array
+        onlyWrong (boolean): Whether to exclusively display incorrect classifications
+
+    Returns:
+        prediction (boolean array): The set of classifications made by the model, only returned if they were all correct
+        probability (tensor array): The set of probabilities assigned to each class by the binary classification model
+    """
     probability = infer(image)
     prediction = probability > threshold
     is_correct = (actual_label[0] == 1) == prediction
@@ -81,6 +131,17 @@ def infer_and_display(image, threshold, actual_label, onlyWrong=False):
 
 
 def example_init(examples=20, display=True):
+    """
+    An example function for the classification process, for demonstration purposes and as a tutorial for usage
+
+    Args:
+        examples (int): The number of images to be loaded from the training dataset.
+        display (boolean): Whether to display the results of each classification, which pauses the program until
+            each individual classification display window is closed.
+
+    Returns:
+        None
+    """
     dataset = classUtils.CrosswalkDataset(data_path)
     
     random_points = [random.randint(0, len(dataset)-1) for i in range(examples)]

--- a/classificationScreening/utils/classUtils.py
+++ b/classificationScreening/utils/classUtils.py
@@ -11,7 +11,16 @@ from PIL import Image
 
 # The custom dataset object I used to load the segmented image dataset
 class CrosswalkDataset(Dataset):
+    """
+    A custom dataset class that is used to store and load the segmented image dataset used in training the 
+    classifiaction model.
+    """
     def __init__(self, src_dir, transform=None):
+        """
+        Args:
+            src_dir (string): The path to the source directory for the data stored by our model
+            transform (pytorch transform object): The pre-processing transform used before accessing any item in the dataset
+        """
         self.src_dir = src_dir
         self.transform = transform
 
@@ -20,9 +29,24 @@ class CrosswalkDataset(Dataset):
         self.label_paths = [file_path for file_path in dir_files if file_path.endswith(".txt")]
 
     def __len__(self):
+        """
+        Returns the length of the dataset, required for the instanciation of the object
+        """
         return len(self.image_paths)
     
     def __getitem__(self, index):
+        """
+        The access mechanism for any item in the dataset, loading an image from the source 
+        directory along with its associated label. Each individual access loads the image again.
+
+        Args:
+            index (int): The index of the image to be retrieved in alphanumerical ordering by name of file
+        
+        Returns:
+            (image, label):
+                image (depends on transform): A transformed version of the image stored in memory.
+                label (tensor): A binary class label for the retrieved image.
+        """
         image_path = os.path.join(self.src_dir, self.image_paths[index])
         label_path = os.path.join(self.src_dir, self.label_paths[index])
 
@@ -41,9 +65,10 @@ class CrosswalkDataset(Dataset):
         return (self.transform(image), torch.FloatTensor(label))
 
 
-# Mean and Std. are chosen arbitrarily - need to be tuned
-# The image do not have to be resized - the global pooling layer should technically deal with this, but I haven't tested this,
-# so resizing prevents potential inaccuracies from occuring,
+# Mean and Std. have been chosen because they fit the data we're working with. For re-use, please adjust.
+# The image does not have to be resized within the transform, the global pooling layer should deal with this
+# by the model (theoretically, we have not had to worry about this occuring yet), but resizing prevent
+# potential errors if the models chosen do not do this.
 vgg_transform = transforms.Compose([
     transforms.Resize((224, 224)),
     transforms.ToTensor(),

--- a/classificationScreening/utils/dataUtils.py
+++ b/classificationScreening/utils/dataUtils.py
@@ -3,6 +3,20 @@ from shapely.geometry import Polygon
 # Each box has format (x_1, y_1, x_2, y_2) - this does mean this is an estimate.
 # box_1 is the bounding box of the crosswalk, and box_2 is that of the tile.
 def check_box_intersection(box_1, box_2, threshold=0.6):
+    """
+    A variant of Intersection-over-Union calculations that takes into consideration the relative scale
+    difference between the two input boxes by scaling the smaller bounding box by the difference factor.
+    Otherwise the calculation process is the same
+
+    Args:
+        box_1 (float tuple): A pair of (x, y) coordinates forming a non-zero area box (does not have to be regular)
+        box_2 (float tuple): A pair of (x, y) coordinates forming a non-zero area box (does not have to be regular)
+        thresold (float): The minimum scaled IoU value required for the boxes to be classified as intersecting
+
+    Returns:
+        intersection (boolean): Whether the boxes overlap according to the given threshold
+    """
+
     # Threshold is the min IoU required to consider it as having a crosswalk - the minimum percent area of the crosswalk that must be in the tile
     formatted_box_1 = [[box_1[0], box_1[1]], [box_1[2], box_1[1]], [box_1[2], box_1[3]], [box_1[0], box_1[3]]]  # Formatting follows shapely clockwise system
 
@@ -20,6 +34,22 @@ def check_box_intersection(box_1, box_2, threshold=0.6):
         return False
 
 def load_yaml_database(yaml_path):
+    """
+    Gives the structure of a YAML database, required for loading in new YOLO datasets - which we do not do in
+    our case, but can be useful for importing your own datasets.
+
+    Args:
+        yaml_path (string): The path to the yaml database configuration file
+
+    Returns:
+        (train_dir, valid_dir, test_dir), (image_size, classes):
+            train_dir (string): The path to the directory containing the training data
+            valid_dir (string): The path to the directory containing the validation data
+            test_dir (string): The path to the directory containing the testing data
+            image_size (int array): The dimensions of the image in terms of width, height, channels, etc.
+            classes (string array): The names of the different classes represented within the dataset.
+    
+    """
     config_file = None
 
     with open(yaml_path, "r") as file:


### PR DESCRIPTION
Added better comments to functions and classes defined in the classificationScreening directory. Removed some unnecessary development tag style code as well.

No logic changes were made other than moving load_utils's execution code to be within an [if __name__ == "__main__"] statement to prevent accidental running and destroying of the dataset...